### PR TITLE
optionally display tag and context links inline in task text

### DIFF
--- a/lib/imdone-atom.coffee
+++ b/lib/imdone-atom.coffee
@@ -9,6 +9,10 @@ fileService = require './file-service'
 
 module.exports = ImdoneAtom =
   config:
+    showTagsInline:
+      description: 'Display inline tag and context links in task text?'
+      type: 'boolean'
+      default: false
     maxFilesPrompt:
       description: 'How many files is too many to parse without prompting?'
       type: 'integer'


### PR DESCRIPTION
I think that this is pretty straightforward, but my coffeescript is still kind of rough.  Could you review and let me know what you think?

Changes display of a task like this:
![screen shot 2016-01-11 at 11 16 27 am](https://cloud.githubusercontent.com/assets/1420419/12239087/0b3404fe-b855-11e5-83d4-781ef2745e45.png)

to this:
![screen shot 2016-01-11 at 11 14 33 am](https://cloud.githubusercontent.com/assets/1420419/12239090/10701cbe-b855-11e5-90e1-d4c4b7b38222.png)

