### PR TITLE
fixed depreciations

### DIFF
--- a/styles/imdone-atom.less
+++ b/styles/imdone-atom.less
@@ -554,13 +554,13 @@
 
 
 atom-text-editor::shadow .password-lines .line {
-  span.text:before {
+  span.syntax--text:before {
     position: absolute;
     left: 0px;
     top: 0px;
     color: @text-color !important;
   }
-  span.text {
+  span.span.syntax--text {
     color:rgba(0, 0, 0, 0);
   }
 }


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--