### PR TITLE
Update imdone-atom.less

### DIFF
--- a/styles/imdone-atom.less
+++ b/styles/imdone-atom.less
@@ -553,7 +553,7 @@
 }
 
 
-atom-text-editor::shadow .password-lines .line {
+atom-text-editor.editor .password-lines .line {
   span.text:before {
     position: absolute;
     left: 0px;


### PR DESCRIPTION
closes #175

```
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

atom-text-editor::shadow .password-lines .line span.text:before => atom-text-editor.editor .password-lines .line span.syntax--text:before
atom-text-editor::shadow .password-lines .line span.text => atom-text-editor.editor .password-lines .line span.syntax--text
Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.
```